### PR TITLE
gesher can infer webhook service namespace from object namespace

### DIFF
--- a/pkg/controller/namespacedvalidatingrule/data.go
+++ b/pkg/controller/namespacedvalidatingrule/data.go
@@ -119,7 +119,7 @@ func (p *EndpointDataType) Add(t *appv1alpha1.NamespacedValidatingRule) *Endpoin
 	groupMap := namespaceMap[t.Namespace]
 
 	for _, webhook := range t.Spec.Webhooks {
-		webhookConfig := createWebhookConfig(webhook)
+		webhookConfig := createWebhookConfig(webhook, t.Namespace)
 
 		for _, webhookRule := range webhook.Rules {
 			var versionMapList []typeVersionMap
@@ -171,7 +171,7 @@ func (p *EndpointDataType) Add(t *appv1alpha1.NamespacedValidatingRule) *Endpoin
 	return newE
 }
 
-func createWebhookConfig(webhook v1beta1.ValidatingWebhook) WebhookConfig {
+func createWebhookConfig(webhook v1beta1.ValidatingWebhook, namespace string) WebhookConfig {
 	var (
 		failurePolicy v1beta1.FailurePolicyType
 		timeout int32
@@ -187,6 +187,10 @@ func createWebhookConfig(webhook v1beta1.ValidatingWebhook) WebhookConfig {
 		timeout = 30
 	} else {
 		timeout = *webhook.TimeoutSeconds
+	}
+
+	if webhook.ClientConfig.Service != nil && webhook.ClientConfig.Service.Namespace == "" {
+		webhook.ClientConfig.Service.Namespace = namespace
 	}
 
 	return WebhookConfig{

--- a/pkg/controller/namespacedvalidatingrule/data_test.go
+++ b/pkg/controller/namespacedvalidatingrule/data_test.go
@@ -106,6 +106,31 @@ var (
 			}},
 		},
 	}
+
+	resource3 = &v1alpha1.NamespacedValidatingRule{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       uid2,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.NamespacedValidatingRuleSpec{
+			Webhooks: []v1beta1.ValidatingWebhook{{
+				Name: "resource2",
+				ClientConfig: v1beta1.WebhookClientConfig{
+					Service:  &v1beta1.ServiceReference{},
+					CABundle: nil,
+				},
+				Rules: []v1beta1.RuleWithOperations{{
+					Operations: []v1beta1.OperationType{testOp1},
+					Rule: v1beta1.Rule{
+						APIGroups:   []string{testGroup1},
+						APIVersions: []string{testVersion1},
+						Resources:   []string{testResource1},
+					},
+				}},
+			}},
+		},
+	}
+
 )
 
 func TestAdd(t *testing.T) {
@@ -196,6 +221,16 @@ func TestUpdate(t *testing.T) {
 func TestGet(t *testing.T) {
 	endpoindData := &EndpointDataType{}
 	newE := endpoindData.Add(resource2)
+	w := newE.Get(namespace, metav1.GroupVersionResource{Group: testGroup1, Version: testVersion1, Resource: testResource1}, testOp1)
+	assert.NotEmpty(t, w)
+	assert.Len(t, w, 1)
+	assert.Equal(t, w[0].ClientConfig.Service.Namespace, namespace)
+}
+
+func TestRuleNoNamespace(t *testing.T) {
+	endpoindData := &EndpointDataType{}
+	assert.Equal(t, "", resource3.Spec.Webhooks[0].ClientConfig.Service.Namespace, "resource3 doesn''t have an empty service namespace")
+	newE := endpoindData.Add(resource3)
 	w := newE.Get(namespace, metav1.GroupVersionResource{Group: testGroup1, Version: testVersion1, Resource: testResource1}, testOp1)
 	assert.NotEmpty(t, w)
 	assert.Len(t, w, 1)


### PR DESCRIPTION
as these are namespaced rules, we can infer a service's namespace from the namespace of the object if it's an empty string