### PR TITLE
RED-47695: never return from http handler without a response

### DIFF
--- a/pkg/admission-proxy/handler.go
+++ b/pkg/admission-proxy/handler.go
@@ -43,7 +43,15 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// verify the content type is accurate
 	contentType := r.Header.Get("Content-Type")
 	if contentType != "application/json" {
-		log.Info(fmt.Sprintf("contentType=%s, expect application/json", contentType))
+		msg := fmt.Sprintf("contentType=%s, expect application/json", contentType)
+		log.Error(nil, msg)
+
+		w.WriteHeader(400)
+		_, err := w.Write([]byte(msg))
+		if err != nil {
+			log.Error(err, "http write failed")
+		}
+
 		return
 	}
 


### PR DESCRIPTION
fix an error path where we returned without an http error response